### PR TITLE
Update transition-actions.md

### DIFF
--- a/src/Oro/Bundle/WorkflowBundle/Resources/doc/reference/workflow/workflow-entities/transition-actions.md
+++ b/src/Oro/Bundle/WorkflowBundle/Resources/doc/reference/workflow/workflow-entities/transition-actions.md
@@ -415,7 +415,7 @@ OR
             # optional condition configuration
     parameters:
         attribute: $sales_funnel_start_date
-        date: 2014-04-01
+        date: '2014-04-01' # must use quotes because date parameter requires string value
 ```
 
 Create Date Time
@@ -444,7 +444,7 @@ OR
             # optional condition configuration
     parameters:
         attribute: $sales_funnel_start_date
-        time: 2014-04-01 12:12:00
+        time: '2014-04-01 12:12:00' # must use quotes because date parameter requires string value
         timezone: Europe/Kiev
 ```
 


### PR DESCRIPTION
Added quotes and a comment on @create_date and @create_datetime actions because without the quotes the value is interpreted as integer and the object creation fails because it requires a string as input.